### PR TITLE
Get last Insert Id

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -66,6 +66,13 @@ class medoo
 
 		return $this->pdo->exec($query);
 	}
+	
+	public function lastInsertId()
+    	{
+        	return $this->pdo->lastInsertId();
+
+    	}
+    
 
 	public function quote($string)
 	{


### PR DESCRIPTION
Added a function to get lastInsertId. It can use used to get id of last affected row in your table

Example:-

$last_user_id = $database->insert("poll_account",
    array(
    "username" => "foo",
    "email" => "foo@bar.com"
    ));

echo $database->lastInsertId();
