### PR TITLE
Close database connection by destructing PDO

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -406,5 +406,10 @@ class medoo
 	{
 		return $this->pdo->getAttribute(PDO::ATTR_SERVER_INFO);
 	}
+	
+	public function close()
+	{
+		$this->pdo = null;
+	}
 }
 ?>


### PR DESCRIPTION
Added a method close() to close database connection by destructing PDO

Uses:- 

$database = new medoo('test');
$data = $database->query('Select * from table')->fetchAll();
$database->close(); // Close method destroy PDO