### PR TITLE
Method to returns the name of the database type

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -406,5 +406,10 @@ class medoo
 	{
 		return $this->pdo->getAttribute(PDO::ATTR_SERVER_INFO);
 	}
+	
+	public function get_database_type() 
+	{
+        	return $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+    	}
 }
 ?>


### PR DESCRIPTION
Added a method to returns the name of the database type/brand: i.e. mysql, db2 etc.

Uses:- 
$database = new medoo('test');
print_r($database->get_database_type());
