### PR TITLE
Allow escaped strings for BETWEEN conditions

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -152,9 +152,16 @@ class medoo
 					{
 						if ($match[3] == '<>')
 						{
-							if (is_array($value) && is_numeric($value[0]) && is_numeric($value[1]))
+							if (is_array($value))
 							{
-								$wheres[] = $match[1] . ' BETWEEN ' . $value[0] . ' AND ' . $value[1];
+								if (is_numeric($value[0]) && is_numeric($value[1]))
+								{
+									$wheres[] = $match[1] . ' BETWEEN ' . $value[0] . ' AND ' . $value[1];
+								}
+								else
+								{
+									$wheres[] = $match[1] . ' BETWEEN ' . $this->quote($value[0]) . ' AND ' . $this->quote($value[1]);
+								}
 							}
 						}
 						else


### PR DESCRIPTION
Actually Medoo refuses BETWEEN condition if values are non numeric whereas according to SQL refs we can do BETWEEN conditions for date fields. So we should allow escaped strings.
