### PR TITLE
[Fix] Allow NULL values for INSERT and UPDATE

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -387,7 +387,8 @@ class medoo
 
 		foreach ($data as $key => $value)
 		{
-			$values[] = is_array($value) ? serialize($value) : $value;
+			if (is_array($value)) $values[] = serialize($value);
+			elseif (is_null($value)) $values[] = 'NULL';
 		}
 
 		$this->exec('INSERT INTO ' . $table . ' (' . $keys . ') VALUES (' . $this->data_implode(array_values($values), ',') . ')');
@@ -404,6 +405,10 @@ class medoo
 			if (is_array($value))
 			{
 				$fields[] = $key . '=' . $this->quote(serialize($value));
+			}
+			elseif (is_null($value))
+			{
+				$fields[] = $key . '= NULL';
 			}
 			else
 			{


### PR DESCRIPTION
I got problems using NULL values in MYSQL : Medoo does not accept inserting NULL values.

In my case it always fill my numeric field at 0 wheras it accepts null values.

It turns that Medoo cast NULL values into numeric values, transforming NULL to 0 before DB insersion/update.
