### PR TITLE
[fix] Adding negative conditions for NULL/Array and fix integer

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -168,9 +168,32 @@ class medoo
 				preg_match('/([\w\.]+)(\[(\>|\>\=|\<|\<\=|\!|\<\>)\])?/i', $key, $match);
 				if (isset($match[3]))
 				{
-					if ($match[3] == '' || $match[3] == '!')
+					if ($match[3] == '')
 					{
 						$wheres[] = $this->column_quote($match[1]) . ' ' . $match[3] . '= ' . $this->quote($value);
+					}
+					elseif($match[3] == '!')
+					{
+						$column = $this->column_quote($match[1]);
+						
+						switch (gettype($value))
+						{
+							case 'NULL':
+								$wheres[] = $column . ' IS NOT null';
+								break;
+
+							case 'array':
+								$wheres[] = $column . ' NOT IN (' . $this->array_quote($value) . ')';
+								break;
+
+							case 'integer':
+								$wheres[] = $column . ' != ' . $value;
+								break;
+
+							case 'string':
+								$wheres[] = $column . ' != ' . $this->quote($value);
+								break;
+						}
 					}
 					else
 					{


### PR DESCRIPTION
Hi, the negative condition is buggy and should have a different behaviour.

for example :

```
'column_name[!]' => null  
Should generate SQL : column_name IS NOT null

'column_name[!]' => [1, 2, 3, 4]
Should generate SQL : column_name NOT IN (1, 2, 3, 4)

'column_name[!]' => 2
Should generate SQL : column_name != 2
```

The fix correct this behaviours.

It is my contrib for the day. :)

++
