### PR TITLE
Let assign ALIAS to Select Columns

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -124,6 +124,11 @@ class medoo
 		return '`' . str_replace('.', '`.`', $string) . '`';
 	}
 
+	protected function column_quote_as($string)
+    	{
+            return str_replace('.', '`.`', $string);
+    	}
+    
 	protected function array_quote($array)
 	{
 		$temp = array();
@@ -402,10 +407,20 @@ class medoo
 
 		$where_clause = $this->where_clause($where);
 
+		if (is_array($columns)){
+			foreach($columns AS $Columns){
+				$columnsTemp =explode('[>]',$Columns);
+				$columnsVal = ($columnsTemp[1]!='') ? '\'' . $columnsTemp[0] . ' AS '\'' . $columnsTemp[1] . '\'':'\'' .$columnsTemp[0] . '\'';
+				$ColumnsEnd[] = $columnsVal;
+			}
+		}else{
+			$ColumnsEnd[]='\'' .$columns . '\'';
+		}
+
 		$query =
 			$this->query('SELECT ' .
 				(
-					is_array($columns) ? $this->column_quote( implode('`, `', $columns) ) :
+					 is_array($ColumnsEnd) ? $this->column_quote_as( implode(', ', $ColumnsEnd) ) :
 					($columns == '*' ? '*' : '`' . $columns . '`')
 				) .
 				' FROM ' . $table . $where_clause


### PR DESCRIPTION
Hi

If you need this query:

Select a.name, b.name from section as a left join gallery as b on(a.idsection=b.section_idsection)

In the Medoo format:

$Data = $database->select("section", 
[
"[>]gallery" => ["idsection" => "section_idsection"]
], 
[
"section.name",
"gallery.name",
]
]);

But you can't differentiate between NAME of Section or NAME of GALLERY. You need have an ALIAS in the query.

And now, the new format to take the query is:

$Data = $database->select("section", 
[
"[>]gallery" => ["idsection" => "section_idsection"]
], 
[
"section.name",
"gallery.name[>]NameGallery",
]
]);
