### PR TITLE
Stop NOW() being escaped

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -119,7 +119,7 @@ class medoo
 
 	public function quote($string)
 	{
-		return ($string == 'NOW()') ? 'NOW()' : $this->pdo->quote($string);
+		return ($string === 'NOW()') ? 'NOW()' : $this->pdo->quote($string);
 	}
 
 	protected function column_quote($string)


### PR DESCRIPTION
NOW() values where being escaped, added a check for them and skip escaping.

```
$database->insert('user',['name' => 'Joe Bloggs','email' => 'joe@blog.com','created_at' => 'NOW()']);
```
