### PR TITLE
[feature] Rename $queryString to $query_string and add support for PDO prepare

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -140,6 +140,13 @@ class medoo
 		return $this->pdo->exec($query);
 	}
 
+	public function prepare($query)
+	{
+		$this->query_string = $query;
+
+		return $this->pdo->prepare($query);
+	}
+
 	public function quote($string)
 	{
 		return $this->pdo->quote($string);


### PR DESCRIPTION
Rename 
$queryString to $query_string, 
$this->queryString to $this->query_string

for consistently naming variable with underscore

and add support for PDO prepare that returns a PDOStatement object

$medoo = new medoo();
$sth = $medoo->prepare("SELECT \* FROM countries WHERE Population > :population");
$sth->execute(array(':population' => 103000));
$data = $sth->fetchAll();

Sorry I don't know why your commit include on my pull request. :smiley: 
