### PR TITLE
Added Google Cloud SQL support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 * **Powerful** - Support various common and complex SQL queries.
 
-* **Compatible** - Support various SQL database, including MySQL, MSSQL, SQLite, MariaDB, Sybase, Oracle, PostgreSQL and more.
+* **Compatible** - Support various SQL database, including MySQL, MSSQL, SQLite, MariaDB, Sybase, Oracle, PostgreSQL, Google Cloud SQL and more.
 
 * **Security** - Prevent SQL injection.
 
@@ -41,7 +41,20 @@ $database = new medoo([
     'username' => 'your_username',
     'password' => 'your_password',
 ]);
+
+// For Google Cloud SQL
+$database = new medoo([
+    'database_type' => 'cloudsql',
+    'database_name' => 'name',
+    'server' => 'instance-id:database-id',
+    'username' => 'your_username',
+    'password' => 'your_password',
+]);
 ```
+
+### Google Cloud SQL Server Name
+
+When using Google Cloud SQL, the "server" variable when initializing Medoo is in the form of "instance-id:database-id", for example, "regal-panther-523:db". This is listed as the "Instance ID" within the Google Developer Console's Cloud SQL administration interface.
 
 ### Contribution Guides
 
@@ -51,7 +64,7 @@ On develop branch, each commits are started with `[fix]`, `[feature]` or `[updat
 
 Keep it simple and keep it clear.
 
-### Liscense
+### License
 
 Medoo is under the MIT License.
 

--- a/medoo.php
+++ b/medoo.php
@@ -11,7 +11,7 @@ class medoo
 {
 	protected $database_type = 'mysql';
 
-	// For MySQL, MariaDB, MSSQL, Sybase, PostgreSQL, Oracle
+	// For MySQL, MariaDB, MSSQL, Sybase, PostgreSQL, Oracle, Google Cloud SQL
 	protected $server = 'localhost';
 
 	protected $username = 'username';
@@ -74,6 +74,12 @@ class medoo
 				case 'mariadb':
 					$type = 'mysql';
 
+				case 'cloudsql':
+					$dsn = 'mysql:unix_socket=/cloudsql/' . $this->server . ';dbname=' . $this->database_name;
+					$commands[] = 'SET SQL_MODE=ANSI_QUOTES';
+					$commands[] = $set_charset;
+					break;		
+					
 				case 'mysql':
 					// Make MySQL using standard quoted identifier
 					$commands[] = 'SET SQL_MODE=ANSI_QUOTES';


### PR DESCRIPTION
Google Cloud SQL support is enabled by instantiating a new Medoo instance as usual. 

Set the following parameters: 

database_type = 'cloudsql'
database_name = '<your database name>'
server = '<your-project-id>:<your-instance-name>'
username = '<username>'
passord = '<password>'

For 'server', an example would be: might-oak-625:db

You can get the project ID and instance name information from your Google Developer Console.