### PR TITLE
Select Queries in Where Clause

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -266,6 +266,20 @@ class medoo
 							case 'string':
 								$wheres[] = $column . ' != ' . $this->fn_quote($key, $value);
 								break;
+								
+							/*
+							 * Adding option for Select Query to be used in Where Statement
+							 * Example
+							 *
+							 * "AND" => [
+							 *      "employees.company" => (object)['query'=>"(SELECT id FROM companies WHERE email = '".$email."')"],
+							 * ],
+							 *
+							 * Assuming in this example that companies.email is an unique field
+							 */
+							case 'object':
+								$wheres[] = $column . ' = ' . $value->query;
+								break;
 						}
 					}
 					else
@@ -337,6 +351,20 @@ class medoo
 							case 'string':
 								$wheres[] = $column . ' = ' . $this->fn_quote($key, $value);
 								break;
+								
+							/*
+							 * Adding option for Select Query to be used in Where Statement
+							 * Example
+							 *
+							 * "AND" => [
+					         *      "employees.company" => (object)['query'=>"(SELECT id FROM companies WHERE email = '".$email."')"],
+					         * ],
+					         *
+					         * Assuming in this example that companies.email is an unique field
+							 */
+                            case 'object':
+                                $wheres[] = $column . ' = ' . $value->query;
+                                break;
 						}
 					}
 				}
@@ -678,6 +706,20 @@ class medoo
 					case 'string':
 						$values[] = $this->fn_quote($key, $value);
 						break;
+						
+					/*
+					 * Adding option for Select Query to be used in Where Statement
+					 * Example
+					 *
+					 * "AND" => [
+					 *      "employees.company" => (object)['query'=>"(SELECT id FROM companies WHERE email = '".$email."')"],
+					 * ],
+					 *
+					 * Assuming in this example that companies.email is an unique field
+					 */
+                    case 'object':
+                        $values[] = $value->query;
+                        break;
 				}
 			}
 


### PR DESCRIPTION
Adding option for Select Query to be used in Where Statement
Example

"AND" => [
    "employees.company" => (object)['query'=>"(SELECT id FROM companies WHERE email = '".$email."')"],
],

Assuming in this example that companies.email is an unique field.

This would require the developer to use Medoo->quote when building these select queries to keep up the sql injection security feature built into Medoo. But it would allow select queries in the Where clause and avoid having to use a join.