### PR TITLE
Oracle DSN string fix

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -89,7 +89,7 @@ class medoo
 					break;
 
 				case 'oracle':
-					$dsn = 'oci:host=' . $this->server . ($is_port ? ';port=' . $port : '') . ';dbname=' . $this->database_name . ';charset=' . $this->charset;
+					$dsn = 'oci:dbname=//' . $this->server . ($is_port ? ':' . $port : ':1521') . '/' . $this->database_name . ';charset=' . $this->charset;
 					break;
 
 				case 'mssql':


### PR DESCRIPTION
Modified DSN string to conform to PDO Oracle requirements.

Tested this using PHP 5.5.17 and Oracle 11g on OSX.
