### PR TITLE
Updated query() to accept parameters

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -126,13 +126,17 @@ class medoo
 		}
 	}
 
-	public function query($query)
+	public function query($query, $params = array())
 	{
 		$this->queryString = $query;
 
-		return $this->pdo->query($query);
-	}
+		$request = $this->pdo->prepare($query);
 
+		$request->execute($params);
+
+		return $request;
+	}
+	
 	public function exec($query)
 	{
 		$this->queryString = $query;


### PR DESCRIPTION
The query() method required devs to manually escape strings secure SQL
statements. Query has been updated to allow a second (optional)
argument which is passed to PDO (as a parameter) and is sanitized
through PDO. This update should not negatively affect existing
applications using the query() method.

Addresses issue #157 I posted.