### PR TITLE
[suggestion] Support for WHERE on JOIN

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -550,7 +550,14 @@ class medoo
 						// For ['column1' => 'column2']
 						else
 						{
-							$relation = 'ON ' . $table . '."' . key($relation) . '" = "' . $match[3] . '"."' . current($relation) . '"';
+							if(is_string(key(array_slice($relation, 1, 1, true))))
+							{
+								$join_where = ' AND ' . substr($this->where_clause(array_slice($relation, 1, count($relation)-1, true)), 7);
+							} else {
+								$join_where = '';
+							}
+							
+							$relation = 'ON ' . $table . '."' . key($relation) . '" = "' . $match[3] . '"."' . current($relation) . '"' . $join_where;
 						}
 					}
 


### PR DESCRIPTION
I couldn't find a way to filter the table I was joining, so I added these five lines of code to do that if you pass more options to the JOIN.

My PHP might not be very good though.
I'll explain it. `is_string(key(array_slice($relation, 1, 1, true)))` does the following: It checks if there's anything at the [1] position in the array, and slices it off. `key()` pulls off the key and checks it it `is_string()` (which it has to be in order for it to be useful in a WHERE clause).

Also, it has to start with `AND`, so I just remove the start of the output with `substr` and replace it.

I'm sure you can do this in a prettier way, but it fixed a problem I was having, at least.
