### PR TITLE
[feature] experimental Firebird DB support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "catfan/medoo",
 	"type": "framework",
 	"description": "The Lightest PHP database framework to accelerate development",
-	"keywords": ["database", "SQL", "MySQL", "MSSQL", "SQLite"],
+	"keywords": ["database", "SQL", "MySQL", "MSSQL", "SQLite", "Firebird"],
 	"homepage": "http://medoo.in",
 	"license": "MIT",
 	"authors": [
@@ -17,7 +17,8 @@
 		"ext-pdo_sqlsrv": "For MSSQL databases on Windows platform",
 		"ext-pdo_dblib": "For MSSQL databases on Liunx/UNIX platform",
 		"ext-pdo-pqsql": "For PostgreSQL databases",
-		"ext-pdo-sqlite": "For SQLite databases"
+		"ext-pdo-sqlite": "For SQLite databases",
+		"ext-pdo-firebird": "For Firebird databases"
 	},
 	"autoload": {
 		"files": ["medoo.php"]

--- a/medoo.php
+++ b/medoo.php
@@ -107,6 +107,10 @@ class medoo
 					$dsn = 'oci:dbname=//' . $this->server . ($is_port ? ':' . $port : ':1521') . '/' . $this->database_name . ';charset=' . $this->charset;
 					break;
 
+				case 'firebird':
+					$dsn = 'firebird:dbname='.$this->server.':'.$this->database_file;
+					break;
+
 				case 'mssql':
 					$dsn = strstr(PHP_OS, 'WIN') ?
 						'sqlsrv:server=' . $this->server . ($is_port ? ',' . $port : '') . ';database=' . $this->database_name :
@@ -144,6 +148,14 @@ class medoo
 	public function query($query)
 	{
 		array_push($this->logs, $query);
+
+		/* Firebird doesn't support quoted strings for table and column names
+		 There might be a more elegant solution to this,
+		 but I wasn't able to prevent column_quote from doing its thing.
+		*/
+		if (strtolower($this->database_type) == "firebird") {
+			$query = str_replace('"', '', $query);
+		}
 
 		return $this->pdo->query($query);
 	}

--- a/medoo.php
+++ b/medoo.php
@@ -155,7 +155,7 @@ class medoo
 	public function exec($query)
 	{
 		array_push($this->logs, $query);
-		echo $query.'<br>';
+		//echo $query.'<br>';
 
 		return $this->pdo->exec($query);
 	}
@@ -391,7 +391,7 @@ class medoo
 				}
 			}
 		}
-		print_r($wheres);
+
 		return implode($conjunctor . ' ', $wheres);
 	}
 
@@ -554,7 +554,6 @@ class medoo
 			}
 		}
 
-		echo $where_clause.'<br>';
 		return $where_clause;
 	}
 
@@ -860,7 +859,23 @@ class medoo
 
 	public function delete($table, $where)
 	{
-		return $this->exec('DELETE FROM "' . $table . '"' . $this->where_clause($where));
+		if (strtolower($this->database_type) == "firebird") {
+			$query = 'DELETE FROM ' . $table . ' ' . $this->where_clause($where);
+			$success = $this->exec($query);
+		} else {
+			$query = 'DELETE FROM "' . $table . '"' . $this->where_clause($where);
+			$success = $this->exec($query);
+		}
+
+		echo $success.'<br>';
+		if (!$success) {
+			echo "<br><b>DELETE ERROR</b><br>";
+			echo "<b>Query:</b> ".$query.'<br>';
+			echo "Does the row exist?<br>";
+			return NULL;
+		}
+
+		return $success;
 	}
 
 	public function replace($table, $columns, $search = null, $replace = null, $where = null)


### PR DESCRIPTION
# Firebird support

Adding support for the Firebird database. For now, only two changes were made to medoo.php:
- The data source name format for Firebird was added. Similarly to SQLite, Firebird requires the `database_file` string.
- Before running a query, double-quotes are removed. This is because Medoo by default adds double-quotes around column and table names, but Firebird doesn't support that. The solution is dirty and I'll think of a better way of doing that. Originally I wanted to wrap around the `column_quote` function, but that gave me a segmentation fault in Apache that I couldn't trace.

For now, simple "select ... from ... where" queries are functional. I plan on adding support for other and more complicated queries in the future.

**Attention**
While testing, I came across  a bug in the PDO Firebird driver that resulted in the first row of the results always being null. Information about that bug can be found [here](https://bugs.php.net/bug.php?id=35386). The solution in the second-to-last comment on that bug request worked for me, so go ahead and re-build that driver!

Cheers,
Renan
