### PR TITLE
add additional conditions to join, ref. #167

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -564,7 +564,21 @@ class medoo
 						// For ['column1' => 'column2']
 						else
 						{
-							$relation = 'ON ' . $table . '."' . key($relation) . '" = "' . (isset($match[5]) ? $match[5] : $match[3]) . '"."' . current($relation) . '"';
+							$and_relation = 'ON ' . $table . '."' . key($relation) . '" = "' . (isset($match[5]) ? $match[5] : $match[3]) . '"."' . current($relation) . '"';
+							// if there is more than one condition
+							if (count($relation) > 1) {
+								
+								// remove the "ON" part
+								array_shift($relation);
+
+								// add the condition to the join
+								foreach ($relation as $key => $value) {
+									$and_relation .= ' AND "' . (isset($match[5]) ? $match[5] : $match[3]) . '"."' . $key . '" = ' . $value;
+								}
+							}
+
+							// write our new relation back
+							$relation = $and_relation;
 						}
 					}
 

--- a/medoo.php
+++ b/medoo.php
@@ -573,7 +573,14 @@ class medoo
 
 								// add the condition to the join
 								foreach ($relation as $key => $value) {
-									$and_relation .= ' AND "' . (isset($match[5]) ? $match[5] : $match[3]) . '"."' . $key . '" = ' . $value;
+									// if the [$] value modifier is present
+									if (preg_match('/\[\${1}\]/', $key) === 1) {
+										$key = preg_replace('/\[\${1}\]/', '', $key);
+										$and_relation .= ' AND "' . (isset($match[5]) ? $match[5] : $match[3]) . '"."' . $key . '" = ' . $value;
+										continue;
+									}
+									// add additional table_relation
+									$and_relation .= ' AND ' . $table . '."' . $key . '" = "' . (isset($match[5]) ? $match[5] : $match[3]) . '"."' . $value . '"';
 								}
 							}
 


### PR DESCRIPTION
This change makes it possible to add additional conditions to a join as discussed in #167; 

If the addition is a value with the joined table use the modifier `[$]`:

```
'right_table_column[$]' => value
```

If it is a table relation use it as any other join condition 

```
'left_table_column' => 'right_table_column'
```
