### PR TITLE
Added two useful features

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -571,7 +571,16 @@ class medoo
 						// For ['column1' => 'column2']
 						else
 						{
-							$relation = 'ON ' . $table . '."' . key($relation) . '" = "' . (isset($match[5]) ? $match[5] : $match[3]) . '"."' . current($relation) . '"';
+							if(strpos(key($relation), '.') !== false)
+							{
+								$custom_join = explode('.', key($relation)); // 0 => Table name, 1 => Table Column
+
+								$relation = 'ON "' . $custom_join[0] . '"."' . $custom_join[1] . '" = "' . (isset($match[5]) ? $match[5] : $match[3]) . '"."' . current($relation) . '"';
+							}
+							else
+							{
+								$relation = 'ON ' . $table . '."' . key($relation) . '" = "' . (isset($match[5]) ? $match[5] : $match[3]) . '"."' . current($relation) . '"';
+							}
 						}
 					}
 

--- a/medoo.php
+++ b/medoo.php
@@ -221,7 +221,7 @@ class medoo
 				/* Using alias */
 				if(isset($match[2]))
 				{
-					array_push($stack, $value . ' AS ' . $match[2]);
+					array_push($stack, $value . ' AS ' . $this->column_quote($match[2]));
 				}
 				else
 				{

--- a/medoo.php
+++ b/medoo.php
@@ -210,7 +210,25 @@ class medoo
 		{
 			preg_match('/([a-zA-Z0-9_\-\.]*)\s*\(([a-zA-Z0-9_\-]*)\)/i', $value, $match);
 
-			if (isset($match[1], $match[2]))
+			$unescaped_match = strpos($value, '[') !== false && strpos($value, ']') !== false;
+
+			if($unescaped_match)
+			{
+				preg_match('/([a-zA-Z0-9_\-\.\[\]]*)\s*\(([a-zA-Z0-9_\-]*)\)/i', $value, $match);
+
+				$value = str_replace(['[', ']'], ['(', ')'], $match[1]);
+
+				/* Using alias */
+				if(isset($match[2]))
+				{
+					array_push($stack, $value . ' AS ' . $match[2]);
+				}
+				else
+				{
+					array_push($stack, $value);
+				}
+			}
+			else if (isset($match[1], $match[2]))
 			{
 				array_push($stack, $this->column_quote( $match[1] ) . ' AS ' . $this->column_quote( $match[2] ));
 			}

--- a/medoo.php
+++ b/medoo.php
@@ -214,7 +214,7 @@ class medoo
 
 			if($unescaped_match)
 			{
-				preg_match('/([a-zA-Z0-9_\-\.\[\]]*)\s*\(([a-zA-Z0-9_\-]*)\)/i', $value, $match);
+				preg_match('/([a-zA-Z0-9_\.\,\[\]]*)\s*\(([a-zA-Z0-9_\-]*)\)/i', $value, $match);
 
 				$value = str_replace(['[', ']'], ['(', ')'], $match[1]);
 


### PR DESCRIPTION
<p>1) You can now join table columns from other joined tables.
When specifying column use: {table name}.{table column}</p>
<pre>
$join = [
'[>]wallets_banks' => ['bank_id' => 'ID'],
'[>]users_aliases' => ['wallets_banks.owner_id' => 'ID'],
];
</pre>
<p>2) Also now you can use SQL functions in column names such as SUM() when selecting from table(s). Adding this column will execute SUM function with a given argument between [] and with alias between ()</p>
<pre>
'SUM[storage_files.size](capacity_used)',
</pre>
<p>SQL:</p>
<pre>
SUM(storage_files.size) AS capacity_used
</pre>

<p>Functions with multiple arguments can also be used:</p>
<pre>
'LEFT[info_list.description,25](description)'
</pre>