### PR TITLE
[update] Error Function

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -916,7 +916,11 @@ class medoo
 
 	public function error()
 	{
-		return $this->pdo->errorInfo();
+		if ($this->pdo->errorCode() !== '00000' OR $this->pdo->errorInfo()[2] !== null)
+		{
+			return $this->pdo->errorInfo();
+		}
+		return FALSE;
 	}
 
 	public function last_query()


### PR DESCRIPTION
By this update, error function returns FALSE if no “SQLSTATE error
code” is set and also no “Driver specific error message” is found.
