### PR TITLE
[feature] headers/column names as array

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -41,6 +41,8 @@ class medoo
 
 	protected $debug_mode = false;
 
+	const MAX_COLUMNS = 65535;
+
 	public function __construct($options = null)
 	{
 		try {
@@ -193,6 +195,21 @@ class medoo
 	{
 		return $this->pdo->quote($string);
 	}
+
+	public function headers($table)
+	{
+        $statement = $this->pdo->query("SELECT * FROM `" . $table . "`");
+
+        for ($i = 0; $i < self::MAX_COLUMNS; $i++) {
+            $meta = $statement->getColumnMeta($i);
+            if (!empty($meta["name"])) {
+               $headers[] = $meta["name"];
+            } else {
+                break;
+            }
+          }  
+        return $headers;
+    }
 
 	protected function column_quote($string)
 	{


### PR DESCRIPTION
Hi,

this function might be useful e.g. when importing CSV files as a check if the headers of the CSV file are the same as the ones in the database. I didn't know how to call them, so I called them headers. If you can think of a name that makes more sense, please change it ;-) The function gives back an array numbered from 0-n with the column names.

As `getColumnMeta()`[1] only works for 1 column at a time, you have to go from `0` to `MAX_COLUMN`. Since `MAX_COLUMN` is unknown and the hard limit depends also on the database type and column types, I chose max 16bit unsigned Integer, hope that makes somewhat sense. Most of the databases can only do 32000 or even 1024 like MySQL[2].

Another way to do this would be quick and dirty:

```
$firstColumn = $connection->get($table, "*");
if (!empty($firstColumn)) {        
    $headers = array();
    foreach ($firstColumn as $header => $value) {
        $headers[] = $header;
     }
}
```

Best regards

[1] https://secure.php.net/manual/de/pdostatement.getcolumnmeta.php
[2] https://dev.mysql.com/doc/refman/5.0/en/column-count-limit.html
