### PR TITLE
Added support for special columns "COUNT", "MAX" etc in "columns" array

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -207,17 +207,18 @@ class medoo
 
 		$stack = array();
 
-		foreach ($columns as $key => $value)
-		{
+		foreach ($columns as $key => $value) {
 			preg_match('/([a-zA-Z0-9_\-\.]*)\s*\(([a-zA-Z0-9_\-]*)\)/i', $value, $match);
 
-			if (isset($match[ 1 ], $match[ 2 ]))
+			$is_special_column = $this->is_special_column($key);
+
+			if (isset($match[1], $match[2]))
 			{
-				array_push($stack, $this->column_quote( $match[ 1 ] ) . ' AS ' . $this->column_quote( $match[ 2 ] ));
-			}
-			else
-			{
-				array_push($stack, $this->column_quote( $value ));
+				$value = $this->column_quote($match[1]);
+				array_push($stack, ($is_special_column ? $key . "(" . $value . ")" : $value) . ' AS ' . $this->column_quote($match[2]));
+			} else {
+				$value = $this->column_quote($value);
+				array_push($stack, ($is_special_column ? $key . "(" . $value . ")" : $value));
 			}
 		}
 
@@ -653,6 +654,12 @@ class medoo
 		}
 
 		return 'SELECT ' . $column . ' FROM ' . $table . $this->where_clause($where);
+	}
+
+	public function is_special_column($column)
+	{
+		$special_columns = ["COUNT", "MAX", "MIN", "SUM", "AVG", "ROUND"];
+		return in_array($column, $special_columns, true);
 	}
 
 	public function select($table, $join, $columns = null, $where = null)


### PR DESCRIPTION
Supported columns "COUNT", "MAX", "MIN", "SUM", "AVG", "ROUND" in "columns" array
Fix for #136 issue

Usage: 

``` php
$database->select("table", [
    "COUNT" => "column1",
    "AVG" => "column2",
    "MAX" => "column3",
    "columnX",
    "columnY"
]);
```

Example for feature requested in issue #136

``` php
$data =  $database->select("table", [
    "COUNT" => "thing",
    "thing2"
],[
    "ORDER" => "thing",
    "GROUP" => "thing2"
]);
```
