### PR TITLE
[update] Added "exit_on_errors" Initialization option

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -41,6 +41,8 @@ class medoo
 
 	protected $debug_mode = false;
 
+	protected $exit_on_errors = false;
+
 	public function __construct($options = null)
 	{
 		try {
@@ -140,6 +142,11 @@ class medoo
 				$this->password,
 				$this->option
 			);
+
+			// default behavior is to silently ignore all SQL errors.  Enable PDO::ERRMODE_EXCEPTION to override this
+			if($this->exit_on_errors) {
+				$this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+			}
 
 			foreach ($commands as $value)
 			{


### PR DESCRIPTION
Default behavior is to silently ignore all SQL Select and Update errors
This new option will stop PHP execution and show all SQL errors

Set the new `exit_on_errors` option when configuring Medoo, then issue a bad SQL query to error

```
<?php

require_once "medoo.php";

// Instantiate Medoo with new "exit_on_errors" option
$db = new medoo([
    'database_name' =>  'YOUR_DATABASE',
    'username' =>       'YOUR_USERNAME',
    'password' =>       'YOUR_PASSWORD',
    'database_type' =>  'mysql',
    'server' =>         'localhost',
    'charset' =>        'utf8',

    'exit_on_errors' => true
]);

// Show error on the page when we issue a bad query
$db->query("SELECT null FROM nonexistent_table LIMIT 0");

// otherwise, show a success message
echo "Database query successful";
```
