### PR TITLE
LIMIT Array parsing changed, no error now with Single Array

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -497,12 +497,21 @@ class medoo
 				if (is_numeric($LIMIT))
 				{
 					$where_clause .= ' LIMIT ' . $LIMIT;
-				}
+				} else if(
+                    isset($LIMIT[ 0 ]) &&
+                    !isset($LIMIT[ 1 ])
+                )
+                {
+                    $where_clause .= ' LIMIT ' . $LIMIT[0];
+                }
 
 				if (
 					is_array($LIMIT) &&
 					is_numeric($LIMIT[ 0 ]) &&
-					is_numeric($LIMIT[ 1 ])
+                    (
+                        isset($LIMIT[ 1 ]) &&
+                        is_numeric($LIMIT[ 1 ])
+                    )
 				)
 				{
 					if ($this->database_type === 'pgsql')


### PR DESCRIPTION
Changed LIMIT parsing that 'LIMIT' => [0] could be used, for easier update and usability.
No error will now caused when used 'LIMIT' => [0].
As errors will hit on performance when much are caused.
