### PR TITLE
[feature] Add method fetch_class to make the next select return objec…

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -845,7 +845,22 @@ class medoo
 
 		if ($query)
 		{
-			$data = $query->fetchAll(PDO::FETCH_ASSOC);
+			if ($this->fetch_class)
+			{
+				$data = $query->fetchAll(
+					PDO::FETCH_CLASS,
+					$this->fetch_class['name'],
+					$this->fetch_class['ctorargs']
+				);
+				if ($this->fetch_class['once'])
+				{
+					$this->fetch_class = null;
+				}
+			}
+			else
+			{
+				$data = $query->fetchAll(PDO::FETCH_ASSOC);
+			}
 
 			if (isset($data[ 0 ]))
 			{


### PR DESCRIPTION
Add method fetch_class to make the next select return objects of specified class #308

I amend the commit log to fit the medoo format.

Example:

```PHP
$users = $medoo->fetch_class('UserModel')->select('user', '*', [
    'age[>=]' => 18,
]);

foreach ($users as $user) {
    $user->recentComments = $medoo->fetch_class('CommentModel')->select('comment', '*', [
        'user_id' => $user->id,
        'ORDER' => 'time DESC',
        'LIMIT' => [0, 5],
    ]);
}
```
