### PR TITLE
fix fn_quote() preg_match is not case insensitive

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -250,7 +250,7 @@ class medoo
 
 	protected function fn_quote($column, $string)
 	{
-		return (strpos($column, '#') === 0 && preg_match('/^[A-Z0-9\_]*\([^)]*\)$/', $string)) ?
+		return (strpos($column, '#') === 0 && preg_match('/^[A-Z0-9\_]*\([^)]*\)$/i', $string)) ?
 
 			$string :
 


### PR DESCRIPTION
When doing an insert using the '#' character on the column name do disable quoting, if you use lower case functions (e.g. from_unixtime vs. FROM_UNIXTIME) the preg_match will fail and the value is still quoted.  I added the case-insensitive flag to the fn_quote method's preg_math regular expression to fix this.
