### PR TITLE
Change encoding from 'utf8' to 'utf-8'

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $database = new medoo([
     'server' => 'localhost',
     'username' => 'your_username',
     'password' => 'your_password',
-    'charset' => 'utf8'
+    'charset' => 'utf-8'
 ]);
 
 // Enjoy


### PR DESCRIPTION
'utf8' is an invalid encoding value and never works.
I followed the documentation but always got garbage Chinese characters until I changed 'utf8' to 'utf-8'.