### PR TITLE
Added close() function, isAlive() function & destructor.

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -41,6 +41,9 @@ class medoo
 
 	protected $debug_mode = false;
 
+	// whether the connection has already been closed
+	protected $closed = false;
+
 	public function __construct($options = null)
 	{
 		try {
@@ -964,6 +967,46 @@ class medoo
 		}
 
 		return $output;
+	}
+
+	public function close()
+	{
+		// in PDO you can't explicitly close a connection
+		// you have to set the link to null and wait for the reference counter to do the job ...
+		$this->pdo = null;
+	}
+
+	public function isAlive()
+	{
+		// https://stackoverflow.com/questions/26004807/pdo-how-to-check-if-connection-is-active-for-real
+
+		$old_errlevel = 0;
+
+		try
+		{
+			// reset the error level
+            $old_errlevel = error_reporting(0);
+
+            // test the connection by doing a simple query
+			$this->query("SELECT 1");
+        }
+        catch (PDOException $e)
+        {
+			// set error reporting back to its old level & return false
+			error_reporting($old_errlevel);
+			return false;
+        }
+
+        // set error reporting back to its old level & return true
+        error_reporting($old_errlevel);
+        return true;
+	}
+
+	public function __destruct()
+	{
+		// close the connection if it isn't already closed
+		if(!$this->closed)
+			$this->close();
 	}
 }
 ?>


### PR DESCRIPTION
I added some functions which I was pretty surprised weren't already there. 

Since I'm using Medoo usually for simple, procedural but also long running  scripts to migrate and backup databases and the likes, I needed to be able to close a connection. PDO doesn't allow to do so, so I'm just setting the reference to null within the class. While on it, I also added a destructor.

The second function, `medoo::isAlive()`, is a simple function to check whether a connection is still alive by issuing `SELECT 1` on the connection. Should work on all supported databases & is simple and easy.