### PR TITLE
Added isAlive() function

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -965,5 +965,36 @@ class medoo
 
 		return $output;
 	}
+
+	public function isAlive()
+	{
+		if($this->pdo == null)
+			return false;
+
+		$old_errlevel = 0;
+
+		try
+		{
+			// supress warning if timed out
+			$old_errlevel = error_reporting(0);
+
+			// test the connection by doing a simple query & checking the result
+			// will give "Warning: PDO::query(): MySQL server has gone away" if not supressed
+			if($this->query("SELECT 1") == false)
+				// throw an excecption to avoid duplicate code when the exception attribute is set
+				throw new PDOException("Timed out.");
+		}
+		catch (PDOException $e)
+		{
+			// set error reporting back to its old level & return false
+			error_reporting($old_errlevel);
+			return false;
+		}
+
+		// set error reporting back to its old level & return true
+		error_reporting($old_errlevel);
+		return true;
+
+	}
 }
 ?>


### PR DESCRIPTION
This commit adds an `isAlive` function which checks whether the connection is still alive. It does so by issuing `SELECT 1`. If the connection is dead, it will either throw an exception or issue a warning and return false if `PDO::ERRMODE_EXCEPTION` is unset. The function can handle either by suppressing the warning and putting the statement in a try-catch-block. 

To test the function use the following script:

``` php
<?php // db is mysql where wait_timeout & interactive_timeout is set to 3 secs each
include("medoo.php");

$db = new medoo( /* ... */);

echo $db->isAlive() ? "alive" : "dead", "\n";

sleep(10); // wait for the connection to timeout

// test the connection
echo $db->isAlive() ? "alive" : "dead", "\n";
```

This is a follow-up to #326.
