### PR TITLE
Fixed join query error when the table have a prefix

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -365,7 +365,7 @@ class medoo
 
 					if (in_array($operator, array('>', '>=', '<', '<=')))
 					{
-						if (is_numeric($value))
+						if ($type != 'string' && is_numeric($value))
 						{
 							$wheres[] = $column . ' ' . $operator . ' ' . $value;
 						}

--- a/medoo.php
+++ b/medoo.php
@@ -583,7 +583,7 @@ class medoo
 
 							foreach ($relation as $key => $value)
 							{
-								$joins[] = $this->prefix . (
+								$joins[] = (
 									strpos($key, '.') > 0 ?
 										// For ['tableB.column' => 'column']
 										'"' . str_replace('.', '"."', $key) . '"' :
@@ -592,7 +592,7 @@ class medoo
 										$table . '."' . $key . '"'
 								) .
 								' = ' .
-								'"' . (isset($match[ 5 ]) ? $match[ 5 ] : $match[ 3 ]) . '"."' . $value . '"';
+								'"' . (isset($match[ 5 ]) ? $match[ 5 ] : $this->prefix . $match[ 3 ]) . '"."' . $value . '"';
 							}
 
 							$relation = 'ON ' . implode($joins, ' AND ');

--- a/medoo.php
+++ b/medoo.php
@@ -365,7 +365,8 @@ class medoo
 
 					if (in_array($operator, array('>', '>=', '<', '<=')))
 					{
-						if ($type != 'string' && is_numeric($value))
+						if ($type != 'string' && 
+							is_numeric($value))
 						{
 							$wheres[] = $column . ' ' . $operator . ' ' . $value;
 						}

--- a/medoo.php
+++ b/medoo.php
@@ -41,6 +41,8 @@ class medoo
 
 	protected $debug_mode = false;
 
+	protected $logger;
+
 	public function __construct($options = null)
 	{
 		try {
@@ -73,6 +75,15 @@ class medoo
 			if (isset($options[ 'prefix' ]))
 			{
 				$this->prefix = $options[ 'prefix' ];
+			}
+
+			if (isset($options[ 'logger' ]))
+			{
+				$this->logger = $options[ 'logger' ];
+			}
+
+			if (isset($options[ 'debug_mode' ]) && $options[ 'debug_mode' ]) {
+				$this->debug_mode = true;
 			}
 
 			switch ($type)
@@ -155,11 +166,7 @@ class medoo
 	{
 		if ($this->debug_mode)
 		{
-			echo $query;
-
-			$this->debug_mode = false;
-
-			return false;
+			$this->logger->debug($query);
 		}
 
 		array_push($this->logs, $query);
@@ -171,11 +178,7 @@ class medoo
 	{
 		if ($this->debug_mode)
 		{
-			echo $query;
-
-			$this->debug_mode = false;
-
-			return false;
+			$this->logger->debug($query);
 		}
 
 		array_push($this->logs, $query);


### PR DESCRIPTION
If the table have a prefix, the "join query" will generate a error SQL, like:

SELECT 
    \* 
FROM
    [prefix_]table1 
LEFT JOIN 
    [prefix_]table2 
ON  
    **[prefix_] [prefix_]table1.column = table2.column**

Thank you!
