### PR TITLE
Set app name in MSSQL Connection string

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -111,9 +111,10 @@ class medoo
 					break;
 
 				case 'mssql':
+					$app_name = isset($this->app) ? $this->app : 'PHP Meedo';
 					$dsn = strstr(PHP_OS, 'WIN') ?
-						'sqlsrv:server=' . $this->server . ($is_port ? ',' . $port : '') . ';database=' . $this->database_name :
-						'dblib:host=' . $this->server . ($is_port ? ':' . $port : '') . ';dbname=' . $this->database_name;
+						'sqlsrv:server=' . $this->server . ($is_port ? ',' . $port : '') . ';database=' . $this->database_name . ';app=' . $app_name :
+						'dblib:host=' . $this->server . ($is_port ? ':' . $port : '') . ';dbname=' . $this->database_name . ';app=' . $app_name;
 
 					// Keep MSSQL QUOTED_IDENTIFIER is ON for standard quoting
 					$commands[] = 'SET QUOTED_IDENTIFIER ON';


### PR DESCRIPTION
This string is associated with a connection and can be used with extended events and profiler traces.
