### PR TITLE
[fix] column string bug

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -207,7 +207,7 @@ class medoo
 
 		if (is_string($columns))
 		{
-			$columns = array($columns);
+			return $columns;
 		}
 
 		$stack = array();
@@ -744,6 +744,11 @@ class medoo
 		if ($columns === '*')
 		{
 			return $query->fetchAll(PDO::FETCH_ASSOC);
+		}
+
+		if (is_string($columns))
+		{
+			return $query->fetchAll(PDO::FETCH_COLUMN);
 		}
 
 		while ($row = $query->fetch(PDO::FETCH_ASSOC))


### PR DESCRIPTION
in version 1.0.* 
Select like this 
```php 
$m->select('tags','id',['tag_name'=>'text']) 
```
return arrray like this
```php
Array
(
    [0] => 23
)
```
Select like this
```php 
$m->select('tags',['id'],['tag_name'=>'text']) 
```
return arrray like this
```php
Array
(
    [0] => Array
        (
            [id] => 23
        )
)
```
in version 1.1.* both selects return this
```php
Array
(
    [0] => Array
        (
            [id] => 23
        )
)
```
in docs says [http://medoo.in/api/select](http://medoo.in/api/select)
```php
// Select a column
$datas = $database->select("account", "user_name");
 
// $datas = array(
// 	[0] => "foo",
// 	[1] => "cat"
// )
```
but  version 1.1.* return somtening like this
```php
$datas = array(
[0] => Array
        (
            [user_name] => 'foo'
        ),
[1] => Array
       (
            [user_name] => 'cat'
       )
 )
````

I tried to fix it