### PR TITLE
[fix] Return last id after insert when you're using pgsql driver (Issue: #386)

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -813,7 +813,12 @@ class medoo
 
 			$this->exec('INSERT INTO ' . $this->table_quote($table) . ' (' . implode(', ', $columns) . ') VALUES (' . implode($values, ', ') . ')');
 
-			$lastId[] = $this->pdo->lastInsertId();
+			if ($this->database_type === 'pgsql') {
+				$query = $this->pdo->query('select lastval()');	
+				$lastId[] = $query->fetchColumn();
+			} else {
+				$lastId[] = $this->pdo->lastInsertId();
+			}
 		}
 
 		return count($lastId) > 1 ? $lastId : $lastId[ 0 ];


### PR DESCRIPTION
I did some fixes to insert function can return the last inserted id, since pdo don't return that for postgres.

Source: http://php.net/manual/en/pdo.lastinsertid.php#75200
