### PR TITLE
 Multi-table insert affairs issues

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -827,8 +827,13 @@ class medoo
 				}
 			}
 
-			$this->exec('INSERT INTO ' . $this->table_quote($table) . ' (' . implode(', ', $columns) . ') VALUES (' . implode($values, ', ') . ')');
+			$rs = $this->exec('INSERT INTO ' . $this->table_quote($table) . ' (' . implode(', ', $columns) . ') VALUES (' . implode($values, ', ') . ')');
 
+			if ($rs === false)
+			{
+				return false;
+			}
+			
 			$lastId[] = $this->pdo->lastInsertId();
 		}
 


### PR DESCRIPTION
In a database transaction, if i need to insert many tables, when a write operation fails, the need to return value to determine whether to roll back

``` php
$db->action(function($db){

    global $data;

    try{

        $basic_id = $db->insert('a',$data[0]);

        if ($basic_id === false)
        {
            return false;
        }

        $rlt_1 = $db->insert('b',$data[1]);

        if ($rlt_1 === false)
        {

            return false;
        }

        $rlt_2 = $db->insert('c',$data[2]);

        if ($rlt_2 === false)
        {

            return false;
        }

        return true;

    } catch(PDOException $e) {

        return false;

    } catch(Exception $e) {

        return false;
    }
});

```
