### PR TITLE
add parenthesis in where clause

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -421,6 +421,7 @@ class medoo
 			}
 		}
 
+		$wheres = array_map(function($v){return sprintf('(%s)', $v);}, $wheres);
 		return implode($conjunctor . ' ', $wheres);
 	}
 
@@ -740,7 +741,7 @@ class medoo
 		$column = $where == null ? $join : $columns;
 
 		$is_single_column = (is_string($column) && $column !== '*');
-		
+
 		$query = $this->query($this->select_context($table, $join, $columns, $where));
 
 		$stack = array();
@@ -947,7 +948,7 @@ class medoo
 				{
 					return $data[ 0 ][ preg_replace('/^[\w]*\./i', "", $column) ];
 				}
-				
+
 				if ($column === '*')
 				{
 					return $data[ 0 ];


### PR DESCRIPTION
for example:

$where = array(
    'AND' => array(
        'a[~]' => array('a', 'b', 'c'),
        'b' => 'bbb',
    ),
);

the current medoo will generate sql like:

select \* from xxx where a like '%a%' OR a like '%b%' OR a like '%c% AND b = 'b'

the right syntax should add a parenthesis in the OR clause.

so I thought it is a good idea to add parenthesis to all clause which cause no harm.
just add $wheres = array_map(function($v){return sprintf('(%s)', $v);}, $wheres); is ok.
