### PR TITLE
[feature] Array support of LIKE with AND condition

### DIFF
--- a/medoo.php
+++ b/medoo.php
@@ -297,7 +297,7 @@ class medoo
 			}
 			else
 			{
-				preg_match('/(#?)([\w\.\-]+)(\[(\>|\>\=|\<|\<\=|\!|\<\>|\>\<|\!?~)\])?/i', $key, $match);
+				preg_match('/(#?)([\w\.\-]+)(\[(\>|\>\=|\<|\<\=|\!|\<\>|\>\<|\&\~|\!?~)\])?/i', $key, $match);
 				$column = $this->column_quote($match[ 2 ]);
 
 				if (isset($match[ 4 ]))
@@ -351,7 +351,7 @@ class medoo
 						}
 					}
 
-					if ($operator == '~' || $operator == '!~')
+					if ($operator == '~' || $operator == '!~' || $operator == '&~')
 					{
 						if ($type != 'array')
 						{
@@ -372,7 +372,8 @@ class medoo
 							$like_clauses[] = $column . ($operator === '!~' ? ' NOT' : '') . ' LIKE ' . $this->fn_quote($key, $item);
 						}
 
-						$wheres[] = implode(' OR ', $like_clauses);
+						if($operator=='&~') $wheres[] = implode(' AND ', $like_clauses);
+						else $wheres[] = implode(' OR ', $like_clauses);
 					}
 
 					if (in_array($operator, array('>', '>=', '<', '<=')))


### PR DESCRIPTION
Added feature for array support of LIKE with AND condition

PHP Code Example:
$database->select("person", "id", [
	"city[&~]" => ["lon", "foo", "bar"]
]);

SQL Query:
WHERE "city" LIKE '%lon%' AND "city" LIKE '%foo%' AND "city" LIKE '%bar%'