### PR TITLE
fix postgres insert expression boolean value

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -951,7 +951,10 @@ class Medoo
 							break;
 
 						case 'boolean':
-							$values[] = ($value ? '1' : '0');
+						    if ($this->database_type === 'pgsql')
+						        $values[] = ($value ? 'true' : 'false');
+						    else
+							    $values[] = ($value ? '1' : '0');
 							break;
 
 						case 'integer':

--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -11,6 +11,8 @@ namespace Medoo;
  */
 
 use PDO;
+use Exception;
+use PDOException;
 
 class Medoo
 {


### PR DESCRIPTION
postgres insert bool value requires 'true' or 'false',instead of '1' or '0'