### PR TITLE
Fix id() function for pgsql driver

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -1219,6 +1219,10 @@ class Medoo
 		{
 			return $this->pdo->query('SELECT SCOPE_IDENTITY()')->fetchColumn();
 		}
+		elseif($this->database_type == 'pgsql')
+		{
+			return $this->pdo->query('SELECT lastval()')->fetchColumn();
+		}
 
 		return $this->pdo->lastInsertId();
 	}


### PR DESCRIPTION
The `id()` function now returns `1` all the time for `pgsql` driver.
The fix checks whether the driver is `pgsql` and returns the proper `id`.