### PR TITLE
[fix] id() function for pgsql

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -1355,6 +1355,10 @@ class Medoo
 		{
 			return $this->pdo->query('SELECT SCOPE_IDENTITY()')->fetchColumn();
 		}
+		elseif ($this->database_type == 'pgsql')
+		{
+			return $this->pdo->query('SELECT LASTVAL()')->fetchColumn();
+		}
 
 		return $this->pdo->lastInsertId();
 	}


### PR DESCRIPTION
The `id()` function now returns `1` all the time for `pgsql` driver.
The fix checks whether the driver is `pgsql` and returns the proper `id`.