### PR TITLE
LIMIT syntax for MSSQL

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -822,7 +822,13 @@ class Medoo
 
 				if (
 					isset($where[ 'LIMIT' ]) &&
-					in_array($this->type, ['oracle', 'mssql'])
+					(
+						$this->type==='oracle' || 
+						(
+							$this->type==='mssql' && 
+							$this->info()['server']['SQLServerVersion']>="11" //for sqlserver 2012+
+						)
+				   	)
 				)
 				{
 					$LIMIT = $where[ 'LIMIT' ];
@@ -1008,7 +1014,15 @@ class Medoo
 		{
 			$column = $this->columnPush($columns, $map);
 		}
-
+		if (
+			'mssql' === $this->type && 
+			$this->info()['server']['SQLServerVersion']<"11" && //for SQLSERVER 2000-2008
+			isset($where['LIMIT'])
+		   )
+	     	{
+	       		$limit = is_numeric($where['LIMIT']) ? $where['LIMIT'] : $where['LIMIT'][0];
+	       		$column = 'TOP (' . $limit . ') ' . $column;
+	     	}
 		return 'SELECT ' . $column . ' FROM ' . $table_query . $this->whereClause($where, $map);
 	}
 

--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -835,7 +835,7 @@ class Medoo
 
 					if (is_numeric($LIMIT))
 					{
-						$where_clause .= ' FETCH FIRST ' . $LIMIT . ' ROWS ONLY';
+						$where_clause .= ' OFFSET 0 ROWS FETCH NEXT ' . $LIMIT . ' ROWS ONLY';
 					}
 					elseif (
 						is_array($LIMIT) &&


### PR DESCRIPTION
Compatible with LIMIT syntax for SQLSERVER 2008- and 2012+

Unfortunately, we can not use OFFSET or FETCH before SQLSERVER 2012. So I add a version check and use "SELECT TOP 10 ..." instead for version 2008 and older.

Secondly, we can not use "FETCH FIRST 10 ROWS" in SQLSERVER . So I have to change it to "OFFSET 0 ROWS FETCH NEXT 10 ROWS"

Tested on
Windows 10.0.15063,
PHP 7.1.1,
SQLSERVER 2008 & 2012