### PR TITLE
Inserting decimal values doesn't work

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -1151,10 +1151,9 @@ class Medoo
 							break;
 
 						case 'integer':
-						case 'double':
 							$map[ $map_key ] = [$value, PDO::PARAM_INT];
 							break;
-
+						case 'double':
 						case 'string':
 							$map[ $map_key ] = [$value, PDO::PARAM_STR];
 							break;


### PR DESCRIPTION
PDO does have not predefined constant for decimal values but, I found in lot of resources that decimal values should be inserted as string.
[for example there](https://stackoverflow.com/questions/2718628/pdoparam-for-type-decimal)