### PR TITLE
Check socket and server options simultaneous use

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -45,6 +45,11 @@ class Medoo
 		{
 			return false;
 		}
+		
+		if(isset($options[ 'socket' ]) && isset($options[ 'server' ]))
+		{
+		        return false;
+		}
 
 		if (isset($options[ 'database_type' ]))
 		{


### PR DESCRIPTION
`socket` and `server`  can not be set at the same time in option.