### PR TITLE
[fix] buildRaw and suppor for raw object in join statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,4 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+/nbproject/

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "catfan/medoo",
+	"name": "jdelta/medoo",
 	"type": "framework",
 	"description": "The lightest PHP database framework to accelerate development",
 	"keywords": ["database", "lightweight", "PHP framework", "SQL", "MySQL", "MSSQL", "SQLite", "PostgreSQL", "MariaDB", "Oracle"],

--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -880,7 +880,7 @@ class Medoo
 		return $where_clause;
 	}
 
-	protected function selectContext($table, &$map, $join, &$columns = null, $where = null, $column_fn = null)
+	protected function selectContext($table, &$map, $join, &$columns = null, $where = null, $column_fn = null, $countFoundRows = false)
 	{
 		preg_match('/(?<table>[a-zA-Z0-9_]+)\s*\((?<alias>[a-zA-Z0-9_]+)\)/i', $table, $table_match);
 
@@ -1017,7 +1017,7 @@ class Medoo
 		{
 			$column = $this->columnPush($columns, $map);
 		}
-                if(is_null($column_fn) && $this->type === 'mysql'){
+                if($countFoundRows && $this->type === 'mysql'){
                     return 'SELECT SQL_CALC_FOUND_ROWS ' . $column . ' FROM ' . $table_query . $this->whereClause($where, $map);
                 }
                 return 'SELECT ' . $column . ' FROM ' . $table_query . $this->whereClause($where, $map);
@@ -1143,7 +1143,7 @@ class Medoo
 		}
 	}
 
-	public function select($table, $join, $columns = null, $where = null)
+	public function select($table, $join, $columns = null, $where = null, $countFoundRows = false)
 	{
 		$map = [];
 		$stack = [];
@@ -1155,7 +1155,7 @@ class Medoo
 
 		$is_single = (is_string($column) && $column !== '*');
 
-		$query = $this->exec($this->selectContext($table, $map, $join, $columns, $where), $map);
+		$query = $this->exec($this->selectContext($table, $map, $join, $columns, $where, null, $countFoundRows), $map);
 
 		$this->columnMap($columns, $column_map);
 
@@ -1572,4 +1572,3 @@ class Medoo
                 return (int) $pdoSt->fetchColumn();
 	}
 }
-?>

--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -13,6 +13,7 @@ namespace Medoo;
 use PDO;
 use Exception;
 use PDOException;
+use LogicException;
 
 class Raw {
 	public $map;
@@ -1016,8 +1017,10 @@ class Medoo
 		{
 			$column = $this->columnPush($columns, $map);
 		}
-
-		return 'SELECT ' . $column . ' FROM ' . $table_query . $this->whereClause($where, $map);
+                if(is_null($column_fn) && $this->type === 'mysql'){
+                    return 'SELECT SQL_CALC_FOUND_ROWS ' . $column . ' FROM ' . $table_query . $this->whereClause($where, $map);
+                }
+                return 'SELECT ' . $column . ' FROM ' . $table_query . $this->whereClause($where, $map);
 	}
 
 	protected function columnMap($columns, &$stack)
@@ -1550,6 +1553,23 @@ class Medoo
 		}
 
 		return $output;
+	}
+        /**
+         * Found rows
+         * 
+         * The found rows of the last query without applying the LIMIT clause,
+         * by now only available for MySQL
+         * 
+         * @return int
+         * @throws LogicException
+         */
+        public function foundRows()
+	{
+                if($this->type!='mysql'){
+                    throw new LogicException('This method is method is only available for MySQL');
+                }
+		$pdoSt = $this->query('SELECT FOUND_ROWS()');
+                return (int) $pdoSt->fetchColumn();
 	}
 }
 ?>

--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -385,7 +385,7 @@ class Medoo
 				$raw_map[ $key ] = $this->typeMap($value, gettype($value));
 			}
 
-			$map = $raw_map;
+                        $map = array_merge($map, $raw_map);
 		}
 
 		return $query;
@@ -945,7 +945,7 @@ class Medoo
 										$table . '."' . $key . '"'
 								) .
 								' = ' .
-								$this->tableQuote(isset($match[ 'alias' ]) ? $match[ 'alias' ] : $match[ 'table' ]) . '."' . $value . '"';
+                                                                (($this->isRaw($value))? $this->buildRaw($value, $map) : ($this->tableQuote(isset($match[ 'alias' ]) ? $match[ 'alias' ] : $match[ 'table' ]) . '."' . $value . '"'));
 							}
 
 							$relation = 'ON ' . implode($joins, ' AND ');


### PR DESCRIPTION
1.  Avoid $map overriding when raw object with parameters is used multiple times.
2. Support raw object in join statements.