### PR TITLE
Don't catch the exception

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -224,21 +224,16 @@ class Medoo
 			$commands[] = "SET NAMES '" . $options[ 'charset' ] . "'";
 		}
 
-		try {
-			$this->pdo = new PDO(
-				$dsn,
-				isset($options[ 'username' ]) ? $options[ 'username' ] : null,
-				isset($options[ 'password' ]) ? $options[ 'password' ] : null,
-				$this->option
-			);
+		$this->pdo = new PDO(
+			$dsn,
+			isset($options[ 'username' ]) ? $options[ 'username' ] : null,
+			isset($options[ 'password' ]) ? $options[ 'password' ] : null,
+			$this->option
+		);
 
-			foreach ($commands as $value)
-			{
-				$this->pdo->exec($value);
-			}
-		}
-		catch (PDOException $e) {
-			throw new PDOException($e->getMessage());
+		foreach ($commands as $value)
+		{
+			$this->pdo->exec($value);
 		}
 	}
 

--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -302,12 +302,15 @@ class Medoo
 			);
 		}
 
+		$this->dsn = $dsn;
+
 		$this->pdo = new PDO(
 			$dsn,
 			isset($options[ 'username' ]) ? $options[ 'username' ] : null,
 			isset($options[ 'password' ]) ? $options[ 'password' ] : null,
 			$option
 		);
+
 		foreach ($commands as $value)
 		{
 			$this->pdo->exec($value);


### PR DESCRIPTION
Let it throw the original exception. This allows for example to access the error code, trace, etc.