### PR TITLE
[update] Remove the PHP ending tag "?>"

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -1559,4 +1559,3 @@ class Medoo
 		return $output;
 	}
 }
-?>


### PR DESCRIPTION
I would like to give [#262 [update] Remove Closing tag from end of the file](https://github.com/catfan/Medoo/pull/262) a chance again.

Reasons:
- I dont see advantages for preserving the `?>`.
- `?>` is optional and almost all modern PHP libs omit it (actually I cannot find one preserving it).
- "Accidentally", a new line could be automatically append to the end of PHP file if such a editor preference is set (like in this [PR](https://github.com/catfan/Medoo/pull/772/files#diff-42b309e5f19340c8b59c3dd80b7ccd31R1548)). Everything after the `?>` could possibly be output as HTML before sending HTTP headers and this is wrong.
