### PR TITLE
A batch update that solves the problem of updating fields is caused b…

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -717,7 +717,9 @@ class Medoo
 
 		if (is_array($where))
 		{
-			$where_keys = array_keys($where);
+            $where_keys = array_keys($where);
+            foreach ($where_keys as $v)
+                if ($where[$v] === 0)  $where[$v] = '0';
 
 			$conditions = array_diff_key($where, array_flip(
 				['GROUP', 'ORDER', 'HAVING', 'LIMIT', 'LIKE', 'MATCH']


### PR DESCRIPTION
A batch update that solves the problem of updating fields is caused by the mismatch between the number 0 and the field type.
Why do we do this?We should help users avoid some problems，Just like `Medoo`'s `SELECT` circumvented, but `UPDATE` did not.
In  `SELECT`:
example: $database->select('account', [
             'user_name',
             'email'
         ], [
             'user_id' => 0
         ]);
that`s okey!
But not for `UPDATE`.
only is equal number 0。
