### PR TITLE
[update] Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ PHP 5.4+ and PDO extension installed
 
 Add Medoo to composer.json configuration file.
 ```
-$ composer require catfan/Medoo
+$ composer require catfan/medoo
 ```
 
 And update the composer


### PR DESCRIPTION
Composer package name should be all lowercase.

Composer 1.8.2 (latest) emits a deprecation warning that package name should in lowercase.

```
Deprecation warning: require.catfan/Medoo is invalid, it should not contain uppercase characters.
Please use catfan/medoo instead. Make sure you fix this as Composer 2.0 will error.
```