### PR TITLE
return correct errorinfo when pdo::prepare failed

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -1759,7 +1759,7 @@ class Medoo
 
 	public function error()
 	{
-		return $this->statement ? $this->statement->errorInfo() : null;
+		return $this->statement ? $this->statement->errorInfo() : $this->pdo->errorInfo();
 	}
 
 	public function last()


### PR DESCRIPTION
when the sqlite file is empty or when create table failed, `Medoo::error()` cannot get correct error information