### PR TITLE
[feature] Add cursor() method (select() with generator syntax)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		{"name": "Angel Lai", "email": "angel@catfan.me"}
 	],
 	"require": {
-		"php": ">=5.4",
+		"php": ">=5.5",
 		"ext-pdo": "*"
 	},
 	"suggest": {

--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -1362,6 +1362,44 @@ class Medoo
 		return $result;
 	}
 
+	public function cursor($table, $join, $columns = null, $where = null)
+	{
+		$map = [];
+		$result = [];
+
+		$index = 0;
+
+		$column = $where === null ? $join : $columns;
+
+		$is_single = (is_string($column) && $column !== '*');
+
+		$query = $this->exec($this->selectContext($table, $map, $join, $columns, $where), $map);
+
+		if (!$query)
+		{
+			return false;
+		}
+
+		if ($columns === '*')
+		{
+			while($row = $query->fetch(PDO::FETCH_ASSOC)) {
+				yield $row;
+			}
+		}
+
+		if ($is_single)
+		{
+			while($row = $query->fetch(PDO::FETCH_COLUMN)) {
+				yield $row;
+			}
+		}
+
+		while ($row = $query->fetch(PDO::FETCH_ASSOC))
+		{
+			yield array_intersect_key($row, array_flip($columns));
+		}
+	}
+
 	public function insert($table, $datas)
 	{
 		$stack = [];


### PR DESCRIPTION
This method works like `select()` method, but it uses PHP generators (yield) leading to lower memory consumption. It's more suitable if you want to iterate many records fetched from database.

Returned value of `cursor()` can't be used by PHP's `count()` or some other functions, but it can be iterated using `foreach`.

It requires PHP>=5.5, so I updated the requirement in composer.json.