### PR TITLE
[feature] upsert method: Insert when record is new, or update if exist

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -1516,6 +1516,18 @@ class Medoo
 		return $this->exec('UPDATE ' . $this->tableQuote($table) . ' SET ' . implode(', ', $fields) . $this->whereClause($where, $map), $map);
 	}
 
+	public function upsert($table, $data, $where = null) 
+	{
+		if ($this->has($table, $where)) 
+		{
+			return $this->update($table, $data, $where);
+		} 
+		else 
+		{
+			return $this->insert($table, $data);
+		}
+	}
+
 	public function delete($table, $where)
 	{
 		$map = [];


### PR DESCRIPTION
We often have to check whether the record already exists or not. 
If there is spesific record, then we call method **->update**,
and if it does not exist we call the method **->insert**.

So, I added a method **->upsert** (abbreviation from: update or insert) that automatically detects whether a record exists or not.

**Before:**
```
$user = array('username'=>'john', 'dept' => 'Sales');

if ($database->has('user', ['user'=>'john'])) 
{
    $database->update('user', $user, ['user'=>'john']);

} else {

    $database->insert('user', $user);
}
```
**After:**
```
$user = array('username'=>'john', 'dept' => 'Sales');
$database->upsert('user', $a, ['username' => 'unyil']);

// If username='john' is exist, record will be updated with data in var $user
// If username='john' is not exist, a new record will be inserted 
```

Thanks!

_Btw: English isn’t my first language, so please excuse any mistakes._