### PR TITLE
Update Medoo.php

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -448,7 +448,7 @@ class Medoo
 			'/(([`\']).*?)?((FROM|TABLE|INTO|UPDATE|JOIN)\s*)?\<(([a-zA-Z0-9_]+)(\.[a-zA-Z0-9_]+)?)\>(.*?\2)?/i',
 			function ($matches)
 			{
-				if (!empty($matches[ 2 ] && isset($matches[ 8 ])))
+				if (!empty($matches[ 2 ]) && isset($matches[ 8 ]))
 				{
 					return $matches[ 0 ];
 				}


### PR DESCRIPTION
Parse error: syntax error, unexpected '&&' (T_BOOLEAN_AND), expecting ')' in /www/wwwroot/admin.yaocaicang.com/vendor/catfan/medoo/src/Medoo.php on line 451