### PR TITLE
[fix] Cannot use object of type Medoo\Raw as array

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -1691,16 +1691,20 @@ class Medoo
 			else
 			{
 				$column = $join;
-				unset($columns[ 'ORDER' ]);
-
-				$columns[ 'ORDER' ] = $order_raw;
+				if (is_array($columns))
+				{
+					unset($columns['ORDER']);
+					$columns[ 'ORDER' ] = $order_raw;
+				}
 			}
 		}
 		else
 		{
-			unset($where[ 'ORDER' ]);
-
-			$where[ 'ORDER' ] = $order_raw;
+			if (is_array($where))
+			{
+				unset($where['ORDER']);
+				$where[ 'ORDER' ] = $order_raw;
+			}
 		}
 
 		return $this->select($table, $join, $columns, $where);

--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -1596,12 +1596,16 @@ class Medoo
 		if ($where === null)
 		{
 			$column = $join;
-			unset($columns[ 'LIMIT' ]);
+			if (is_array($columns)) {
+				unset($columns[ 'LIMIT' ]);
+			}
 		}
 		else
 		{
 			$column = $columns;
-			unset($where[ 'LIMIT' ]);
+			if (is_array($where)) {
+				unset($where[ 'LIMIT' ]);
+			}
 		}
 
 		$is_single = (is_string($column) && $column !== '*');


### PR DESCRIPTION
Code: Medoo::raw("WHERE Products.IsActive = 1 AND FIND_IN_SET(" . $group_id . ", GroupIdList) > 0 ")
Error: Cannot use object of type Medoo\Raw as array | File: /var/www/vendor/catfan/medoo/src/Medoo.php, Line: 1449