### PR TITLE
FIX to drop table names with dots in mariaDB

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -1347,7 +1347,7 @@ class Medoo
 	{
 		$tableName = $this->prefix . $table;
 
-		return $this->exec("DROP TABLE IF EXISTS $tableName");
+		return $this->exec("DROP TABLE IF EXISTS `$tableName`");
 	}
 
 	public function select($table, $join, $columns = null, $where = null)


### PR DESCRIPTION
quotes added to escape table names with dots (e.g. table_name.dot) in mariaDB