### PR TITLE
Fix LIMIT syntax error while performing get operation on MSSQL

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -1596,17 +1596,17 @@ class Medoo
 		if ($where === null)
 		{
 			$column = $join;
-			unset($columns[ 'LIMIT' ]);
+			$columns[ 'LIMIT' ] = 1;
 		}
 		else
 		{
 			$column = $columns;
-			unset($where[ 'LIMIT' ]);
+			$where[ 'LIMIT' ] = 1;
 		}
 
 		$is_single = (is_string($column) && $column !== '*');
 
-		$query = $this->exec($this->selectContext($table, $map, $join, $columns, $where) . ' LIMIT 1', $map);
+		$query = $this->exec($this->selectContext($table, $map, $join, $columns, $where), $map);
 
 		if (!$this->statement)
 		{


### PR DESCRIPTION
Fixed by redirecting `LIMIT` responsibility to `whereClause` function