### PR TITLE
[update] ADD where RAW style

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "zsth/medoo",
+	"name": "catfan/medoo",
 	"type": "framework",
 	"description": "The lightweight PHP database framework to accelerate development",
 	"keywords": ["database", "database library", "lightweight", "PHP framework", "SQL", "MySQL", "MSSQL", "SQLite", "PostgreSQL", "MariaDB", "Oracle"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "catfan/medoo",
+	"name": "zsth/medoo",
 	"type": "framework",
 	"description": "The lightweight PHP database framework to accelerate development",
 	"keywords": ["database", "database library", "lightweight", "PHP framework", "SQL", "MySQL", "MSSQL", "SQLite", "PostgreSQL", "MariaDB", "Oracle"],

--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -850,13 +850,17 @@ class Medoo
             ) {
                 $stack[] = '(' . $this->dataImplode($value, $map, ' ' . $relationMatch[1]) . ')';
                 continue;
+            }else if ($type === 'object' && $this->isRaw($value) ) {
+                $raw_result = $this->buildRaw($value, $map);
+                $stack[] = $raw_result;
+                continue;
             }
 
             $mapKey = $this->mapKey();
             $isIndex = is_int($key);
 
             preg_match(
-                '/([\p{L}_][\p{L}\p{N}@$#\-_\.]*)(\[(?<operator>\>\=?|\<\=?|\!|\<\>|\>\<|\!?~|REGEXP|RAW)\])?([\p{L}_][\p{L}\p{N}@$#\-_\.]*)?/u',
+                '/([\p{L}_][\p{L}\p{N}@$#\-_\.]*)(\[(?<operator>\>\=?|\<\=?|\!|\<\>|\>\<|\!?~|REGEXP)\])?([\p{L}_][\p{L}\p{N}@$#\-_\.]*)?/u',
                 $isIndex ? $value : $key,
                 $match
             );
@@ -964,9 +968,6 @@ class Medoo
                 } elseif ($operator === 'REGEXP') {
                     $stack[] = "{$column} REGEXP {$mapKey}";
                     $map[$mapKey] = [$value, PDO::PARAM_STR];
-                } elseif ($operator === 'RAW' && $this->isRaw($value)) {
-                    $raw_result = $this->buildRaw($value, $map);
-                    $stack[] = $raw_result;
                 }
 
                 continue;

--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -850,6 +850,10 @@ class Medoo
             ) {
                 $stack[] = '(' . $this->dataImplode($value, $map, ' ' . $relationMatch[1]) . ')';
                 continue;
+            }else if ($type === 'object' && $this->isRaw($value) ) {
+                $raw_result = $this->buildRaw($value, $map);
+                $stack[] = $raw_result;
+                continue;
             }
 
             $mapKey = $this->mapKey();
@@ -868,7 +872,6 @@ class Medoo
                 $stack[] = "${column} ${operator} " . $this->columnQuote($match[4]);
                 continue;
             }
-
             if ($operator) {
                 if (in_array($operator, ['>', '>=', '<', '<='])) {
                     $condition = "{$column} {$operator} ";

--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -856,7 +856,7 @@ class Medoo
             $isIndex = is_int($key);
 
             preg_match(
-                '/([\p{L}_][\p{L}\p{N}@$#\-_\.]*)(\[(?<operator>\>\=?|\<\=?|\!|\<\>|\>\<|\!?~|REGEXP)\])?([\p{L}_][\p{L}\p{N}@$#\-_\.]*)?/u',
+                '/([\p{L}_][\p{L}\p{N}@$#\-_\.]*)(\[(?<operator>\>\=?|\<\=?|\!|\<\>|\>\<|\!?~|REGEXP|FIND_IN_SET)\])?([\p{L}_][\p{L}\p{N}@$#\-_\.]*)?/u',
                 $isIndex ? $value : $key,
                 $match
             );
@@ -965,6 +965,10 @@ class Medoo
                 } elseif ($operator === 'REGEXP') {
                     $stack[] = "{$column} REGEXP {$mapKey}";
                     $map[$mapKey] = [$value, PDO::PARAM_STR];
+                } elseif ($operator === 'FIND_IN_SET')
+                {
+                    $stack[] = " FIND_IN_SET($mapKey , $column)";
+                    $map[ $mapKey ] = [$value, PDO::PARAM_STR];
                 }
 
                 continue;

--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -850,7 +850,7 @@ class Medoo
             ) {
                 $stack[] = '(' . $this->dataImplode($value, $map, ' ' . $relationMatch[1]) . ')';
                 continue;
-            }else if ($type === 'object' && $this->isRaw($value) ) {
+            }else if ($type === 'object' && $this->isRaw($value) && is_int($key) ) {
                 $raw_result = $this->buildRaw($value, $map);
                 $stack[] = $raw_result;
                 continue;

--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -856,7 +856,7 @@ class Medoo
             $isIndex = is_int($key);
 
             preg_match(
-                '/([\p{L}_][\p{L}\p{N}@$#\-_\.]*)(\[(?<operator>\>\=?|\<\=?|\!|\<\>|\>\<|\!?~|REGEXP|FIND_IN_SET)\])?([\p{L}_][\p{L}\p{N}@$#\-_\.]*)?/u',
+                '/([\p{L}_][\p{L}\p{N}@$#\-_\.]*)(\[(?<operator>\>\=?|\<\=?|\!|\<\>|\>\<|\!?~|REGEXP|RAW)\])?([\p{L}_][\p{L}\p{N}@$#\-_\.]*)?/u',
                 $isIndex ? $value : $key,
                 $match
             );
@@ -868,7 +868,6 @@ class Medoo
                 $stack[] = "${column} ${operator} " . $this->columnQuote($match[4]);
                 continue;
             }
-
             if ($operator) {
                 if (in_array($operator, ['>', '>=', '<', '<='])) {
                     $condition = "{$column} {$operator} ";
@@ -965,10 +964,9 @@ class Medoo
                 } elseif ($operator === 'REGEXP') {
                     $stack[] = "{$column} REGEXP {$mapKey}";
                     $map[$mapKey] = [$value, PDO::PARAM_STR];
-                } elseif ($operator === 'FIND_IN_SET')
-                {
-                    $stack[] = " FIND_IN_SET($mapKey , $column)";
-                    $map[ $mapKey ] = [$value, PDO::PARAM_STR];
+                } elseif ($operator === 'RAW' && $this->isRaw($value)) {
+                    $raw_result = $this->buildRaw($value, $map);
+                    $stack[] = $raw_result;
                 }
 
                 continue;

--- a/tests/WhereTest.php
+++ b/tests/WhereTest.php
@@ -1039,4 +1039,53 @@ class WhereTest extends MedooTestCase
             $this->database->queryString
         );
     }
+
+    
+    /**
+     * @covers ::select()
+     * @covers ::dataImplode()
+     * @covers ::whereClause()
+     * @dataProvider typesProvider
+     */
+    public function testRawWhereOneClause($type)
+    {
+        $this->setType($type);
+
+        $this->database->select(
+            "account",
+            "user_name",
+            [
+                Medoo::raw("ROUND(<float_val>) = :round_value", [':round_value'=>10]),
+                'LIMIT' => [20, 100],
+                'LIMIT' => [20, 100],
+                "ORDER" => "user_id",
+            ]
+        );
+
+        $this->assertQuery([
+            'default' => <<<EOD
+                SELECT "user_name"
+                FROM "account"
+                WHERE ROUND("float_val") = 10
+                ORDER BY "user_id"
+                LIMIT 100 OFFSET 20
+                EOD,
+            'mssql' => <<<EOD
+                SELECT "user_name"
+                FROM "account"
+                WHERE ROUND("float_val") = 10
+                ORDER BY "user_id"
+                OFFSET 20 ROWS FETCH NEXT 100 ROWS ONLY
+                EOD,
+            'oracle' => <<<EOD
+                SELECT "user_name"
+                FROM "account"
+                WHERE ROUND("float_val") = 10
+                ORDER BY "user_id"
+                OFFSET 20 ROWS FETCH NEXT 100 ROWS ONLY
+                EOD,
+        ],
+            $this->database->queryString
+        );
+    }
 }


### PR DESCRIPTION
before: when we use where RAW on SQL_FUNCTION(col_name), we must write whole condition in ONE RAW SQL,
now : You can write one condition in ONE RAW,

In other words, as long as there is an SQL method, all limit, order and group by must be written together. Not elegant


也就是说，之前只要带有一个sql的方法，那所有的LIMIT，ORDER，GROUP BY就都必须写在一起了，很难看

> $data = $database->select('account', [
		'user_id',
		'email'
	],
	Medoo::raw('WHERE
		LENGTH(<user_name>) > 5
		ORDER BY RAND()
		LIMIT 10
	')
);

now you can write it like
> $this->database->select(
            "account",
            "user_name",
            [
                Medoo::raw("ROUND(<float_val>) = :round_value", [':round_value'=>10]),
                'LIMIT' => [20, 100],
                "ORDER" => "user_id",
            ]
        );
