### PR TITLE
fix for issue 1011 - set PDO type int for double vars

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -744,7 +744,7 @@ class Medoo
         $map = [
             'NULL' => PDO::PARAM_NULL,
             'integer' => PDO::PARAM_INT,
-            'double' => PDO::PARAM_STR,
+            'double' => PDO::PARAM_INT,
             'boolean' => PDO::PARAM_BOOL,
             'string' => PDO::PARAM_STR,
             'object' => PDO::PARAM_STR,


### PR DESCRIPTION
set `'double' => PDO::PARAM_INT` to prevent from the value quoting in generator().