### PR TITLE
fix drop function adding database perfix two times

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -1564,7 +1564,7 @@ class Medoo
      */
     public function drop(string $table): ?PDOStatement
     {
-        return $this->exec('DROP TABLE IF EXISTS ' . $this->tableQuote($this->prefix . $table));
+        return $this->exec('DROP TABLE IF EXISTS ' . $this->tableQuote($table));
     }
 
     /**


### PR DESCRIPTION
drop function is was applying prefix two times
example :
`    $database = new Medoo([
    	...
    	"prefix" => "WP_"
    ]);
     
    $database->debug()->drop("account");
//output
DROP TABLE IF EXISTS `WP_WP_account` 
`