### PR TITLE
Fix DateTime Objects when saving

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -1771,6 +1771,16 @@ class Medoo
             $column = $this->columnQuote(preg_replace("/(\s*\[(JSON|\+|\-|\*|\/)\]$)/", '', $key));
             $type = gettype($value);
 
+            if($type === 'object' && $value instanceof \DateTime) {
+                $type = 'string';
+                /** @var \DateTime $value */
+                $value = $value
+                    ->setTimezone(new \DateTimeZone('UTC'))
+                    ->format('Y-m-d h:m:s');
+                // Timezone and milliseconds (Y-m-d h:m:s.U e) are not supported by now by mysql/mariadb
+                // (https://dev.mysql.com/doc/refman/8.0/en/datetime.html)
+            }
+
             if ($this->type === 'oracle' && $type === 'resource') {
                 $fields[] = "{$column} = EMPTY_BLOB()";
                 $returnings[$this->mapKey()] = [$key, $value, PDO::PARAM_LOB];

--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -1776,8 +1776,8 @@ class Medoo
                 /** @var \DateTime $value */
                 $value = $value
                     ->setTimezone(new \DateTimeZone('UTC'))
-                    ->format('Y-m-d h:m:s');
-                // Timezone and milliseconds (Y-m-d h:m:s.U e) are not supported by now by mysql/mariadb
+                    ->format('Y-m-d H:m:s');
+                // Timezone and milliseconds (Y-m-d H:m:s.U e) are not supported by now by mysql/mariadb
                 // (https://dev.mysql.com/doc/refman/8.0/en/datetime.html)
             }
 


### PR DESCRIPTION
According to the [documentation of mysql](https://dev.mysql.com/doc/refman/8.0/en/datetime.html) the engine is unable to handle php-like DateTime Objects. That's why I add a fix for that. The fix turns the DateTime-Object into a string. Before that, the timezone is set to UTC.