### PR TITLE
Add support for modifying the identifier delimiter

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -728,7 +728,7 @@ class Medoo
             $this->identifierDelimiter = $identifierDelimiter . $identifierDelimiter;
         }
 
-		return $this;
+        return $this;
     }
 
     /**

--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -718,15 +718,17 @@ class Medoo
      * like SQL Server where square brackets are used rather than a single character.
      *
      * @param string $identifierDelimiter
-     * @return void
+     * @return Medoo
      */
-    public function setIdentifierDelimiter(string $identifierDelimiter): void
+    public function setIdentifierDelimiter(string $identifierDelimiter): self
     {
         if (strlen($identifierDelimiter) === 2) {
             $this->identifierDelimiter = $identifierDelimiter;
         } elseif (strlen($identifierDelimiter) === 1) {
             $this->identifierDelimiter = $identifierDelimiter . $identifierDelimiter;
         }
+
+		return $this;
     }
 
     /**
@@ -754,7 +756,7 @@ class Medoo
     {
         if (preg_match('/^[\p{L}_][\p{L}\p{N}@$#\-_]*(\.?[\p{L}_][\p{L}\p{N}@$#\-_]*)?$/u', $column)) {
             return strpos($column, '.') !== false ?
-                $this->identifierDelimiter[0] . $this->prefix . str_replace('.', '"."', $column) . $this->identifierDelimiter[1] :
+                $this->identifierDelimiter[0] . $this->prefix . str_replace('.', $this->identifierDelimiter[0] . '.' . $this->identifierDelimiter[1], $column) . $this->identifierDelimiter[1] :
                 $this->identifierDelimiter[0] . $column . $this->identifierDelimiter[1];
         }
 

--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -84,6 +84,15 @@ class Medoo
     protected $prefix;
 
     /**
+     * The identifier delimiter used for quoting table and column names.
+     *
+     * Defaults to the SQL-92 standard delimiter.
+     *
+     * @var string
+     */
+    protected $identifierDelimiter = '""';
+
+    /**
      * The PDO statement object.
      *
      * @var \PDOStatement
@@ -703,6 +712,24 @@ class Medoo
     }
 
     /**
+     * Sets the identifier delimiter for use when quoting tables or columns.
+     *
+     * Ensures it is set to a two-character string for usage with databases
+     * like SQL Server where square brackets are used rather than a single character.
+     *
+     * @param string $identifierDelimiter
+     * @return void
+     */
+    public function setIdentifierDelimiter(string $identifierDelimiter): void
+    {
+        if (strlen($identifierDelimiter) === 2) {
+            $this->identifierDelimiter = $identifierDelimiter;
+        } elseif (strlen($identifierDelimiter) === 1) {
+            $this->identifierDelimiter = $identifierDelimiter . $identifierDelimiter;
+        }
+    }
+
+    /**
      * Quote table name for use in a query.
      *
      * @param string $table
@@ -711,7 +738,7 @@ class Medoo
     public function tableQuote(string $table): string
     {
         if (preg_match('/^[\p{L}_][\p{L}\p{N}@$#\-_]*$/u', $table)) {
-            return '"' . $this->prefix . $table . '"';
+            return $this->identifierDelimiter[0] . $this->prefix . $table . $this->identifierDelimiter[1];
         }
 
         throw new InvalidArgumentException("Incorrect table name: {$table}.");
@@ -727,8 +754,8 @@ class Medoo
     {
         if (preg_match('/^[\p{L}_][\p{L}\p{N}@$#\-_]*(\.?[\p{L}_][\p{L}\p{N}@$#\-_]*)?$/u', $column)) {
             return strpos($column, '.') !== false ?
-                '"' . $this->prefix . str_replace('.', '"."', $column) . '"' :
-                '"' . $column . '"';
+                $this->identifierDelimiter[0] . $this->prefix . str_replace('.', '"."', $column) . $this->identifierDelimiter[1] :
+                $this->identifierDelimiter[0] . $column . $this->identifierDelimiter[1];
         }
 
         throw new InvalidArgumentException("Incorrect column name: {$column}.");


### PR DESCRIPTION
You can test the changes made in this PR directly, but the actual test suite may be expecting the SQL-92 specific syntax so it may not be able to directly run the tests when the identifier delimiter has been changed since the generated queries likely won't match anymore. 

But by default, the changes proposed here should allow the existing test suite to continue to pass without any changes, since it should still be using the double quote identifier delimiter.

Taking input from [Medoo#1044](https://github.com/catfan/Medoo/issues/1044), this adds support for users to modify the quote identifier used for their quotes with databases that might not support the assumed SQL-92 standard double quote delimiter for identifiers.

While I think switching databases into the SQL-92 mode is a good approach generally for making maintenance on the Medoo side simpler, so that the code can be generalized more easily, it's not a workable approach in all situations as described in the issue above by the two PlanetScale users that have run into difficulties.

Similarly though, I could see a Microsoft SQL Server user possibly not wanting to do the same and it causing an issue somehow, although this particular situation does appear to be a bit more PlanetScale specific since the ability for the `ANSI_QUOTES` option is not supported at this time, nor does it seem to be something that will readily become available in the near future. We've documented this limitation on our [MySQL Compatibility](https://planetscale.com/docs/reference/mysql-compatibility) page.

Many libraries do allow for the customization of this identifier for their database-specific drivers, but I do understand the Medoo project's desire to keep things as simple and self-contained as possible and I hope the code suggested in this Pull Request is simple enough that it may be considered for users.

```php
// Require Composer's autoloader.
require 'vendor/autoload.php';

// Using Medoo namespace.
use Medoo\Medoo;

// Connect the database.
$database = new Medoo([
    'type' => 'mysql',
    'host' => 'localhost',
    'database' => 'name',
    'username' => 'your_username',
    'password' => 'your_password'
]);

// Usage example of new setIdentifierDelimiter() method:

// For PlanetScale:
$database ->setIdentifierDelimiter('`');

// For something like SQL Server:
$database ->setIdentifierDelimiter('[]');

// You can also use it in a chained manner if you really wanted to (the delimiter would continue to use the new setting afterward):
$database ->setIdentifierDelimiter('`')->select("my_table", '*');

// The changes also correctly adjust the quotes when using the table.column notation in your column list:
$database ->setIdentifierDelimiter('`')->select("my_table", 'my_table.id');
```

