### PR TITLE
fix: updating function aggregate to return int too

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -2002,7 +2002,7 @@ class Medoo
      * @param array $where
      * @return string|null
      */
-    private function aggregate(string $type, string $table, $join = null, $column = null, $where = null): ?string
+    private function aggregate(string $type, string $table, $join = null, $column = null, $where = null): null|string|int
     {
         $map = [];
 


### PR DESCRIPTION
Running function count at the moment returns this error: 


```
string 'Medoo\Medoo::aggregate(): Return value must be of type ?string, int returned' 
```

This is caused by private function aggregate requiring a string return: 

```
private function aggregate(string $type, string $table, $join = null, $column = null, $where = null): ?string
```
while public function count returns (and requires the return of ) an int type

```
public function count(string $table, $join = null, $column = null, $where = null): ?int
   {
        return (int) $this->aggregate('COUNT', $table, $join, $column, $where);
  }
```

my solution here is adding int return to private function aggregate

```
private function aggregate(string $type, string $table, $join = null, $column = null, $where = null): null|string|int

```



