### PR TITLE
Remove characters `*#_^` for like statement

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -939,7 +939,7 @@ class Medoo
                     foreach ($value as $index => $item) {
                         $item = strval($item);
 
-                        if (!preg_match('/((?<!\\\)\[.+(?<!\\\)\]|(?<!\\\)[\*\?\!\%#^_]|%.+|.+%)/', $item)) {
+                        if (!preg_match('/((?<!\\\)\[.+(?<!\\\)\]|(?<!\\\)[\?\!\%]|%.+|.+%)/', $item)) {
                             $item = '%' . $item . '%';
                         }
 


### PR DESCRIPTION
当like语句中的值包含*#_^四个字符串时，最终拼成的语句会丢掉%符号，导致查询结果不正确，原始逻辑如下（line: 942）：
`
if (!preg_match('/((?<!\\\)\[.+(?<!\\\)\]|(?<!\\\)[\*\?\!\%#^_]|%.+|.+%)/', $item)) {
    $item = '%' . $item . '%';
}
`