### PR TITLE
Medoo Schema Option

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -175,7 +175,7 @@ class Medoo
     public $errorInfo = null;
 
     /**
-     * The schema of table.
+     * Table schema.
      *
      * @var string|null
      */

--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -175,6 +175,13 @@ class Medoo
     public $errorInfo = null;
 
     /**
+     * The schema of table.
+     *
+     * @var string|null
+     */
+    public $schema = null;
+
+    /**
      * Connect the database.
      *
      * ```
@@ -204,6 +211,10 @@ class Medoo
     {
         if (isset($options['prefix'])) {
             $this->prefix = $options['prefix'];
+        }
+
+        if (isset($options['schema'])) {
+            $this->schema = $options['schema'];
         }
 
         if (isset($options['testMode']) && $options['testMode'] == true) {
@@ -711,6 +722,9 @@ class Medoo
     public function tableQuote(string $table): string
     {
         if (preg_match('/^[\p{L}_][\p{L}\p{N}@$#\-_]*$/u', $table)) {
+            if(!empty($this->schema)) {
+                return $this->schema . '."' . $this->prefix . $table . '"';
+            }
             return '"' . $this->prefix . $table . '"';
         }
 

--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -721,9 +721,16 @@ class Medoo
      */
     public function tableQuote(string $table): string
     {
+        $schema = null;
+        if(strpos($table, '.') !== false && empty($this->schema)) {
+            [$schema, $table] = explode('.', $table);
+        }
+        if(!empty($this->schema)) {
+            $schema = $this->schema;
+        }
         if (preg_match('/^[\p{L}_][\p{L}\p{N}@$#\-_]*$/u', $table)) {
-            if(!empty($this->schema)) {
-                return $this->schema . '."' . $this->prefix . $table . '"';
+            if($schema !== null) {
+                return $schema . '."' . $this->prefix . $table . '"';
             }
             return '"' . $this->prefix . $table . '"';
         }


### PR DESCRIPTION
I found myself in a situation where I needed to use another schema, so i made this change  to the tableQuote method and added $this->schema attribute for globally schema

a example of my use:
```php
// in Medoo constructor i pass ['schema' => 'information_schema']
$medoo->select('columns', ['data_type'], ['table_name' => "{$this->table}"]);

// also you can use like this
// in Medoo constructor don't pass ['schema' => 'information_schema']
$medoo->select('information_schema.columns', ['data_type'], ['table_name' => "{$this->table}"]);
```

raw query (Postgresql)
```sql
SELECT "data_type" FROM information_schema."columns"
WHERE  "table_name" = $tableName;
```
