### PR TITLE
add: Support raw in where array

### DIFF
--- a/src/Medoo.php
+++ b/src/Medoo.php
@@ -946,6 +946,11 @@ class Medoo
             $mapKey = $this->mapKey();
             $isIndex = is_int($key);
 
+            if($isIndex && $value instanceof Raw){
+                $stack[] = $this->buildRaw($value, $map);
+                continue;
+            }
+
             preg_match(
                 "/(?<column>" . $this::COLUMN_PATTERN . ")(\[(?<operator>.*)\])?(?<comparison>" . $this::COLUMN_PATTERN . ")?/u",
                 $isIndex ? $value : $key,


### PR DESCRIPTION
## Support raw in where array

$where = [
    Medoo::raw(),
    Medoo::raw(),
];

## demo: 


$medoo->debug()->select("user",["id","username"],[
           'AND'=>[
               'create_time[>]'=>1779465600,
               Medoo::raw("response_json->> '$.error' = 'phone-fail'"),
               Medoo::raw("request_json->> '$.ip' = '127.0.0.1'"),
               'OR'=>[
                   Medoo::raw("response_json->> '$.error' = 'phone'"),
                   Medoo::raw("request_json->> '$.req' = '127.0'"),
               ]
           ],
           'LIMIT'=>10,
       ]);

##  SQL result :

SELECT `id`,`username`,`password` FROM `wf_user` WHERE (`create_time` > 1779465600 AND response_json->> '$.error' = 'phone-fail' AND request_json->> '$.ip' = '127.0.0.1' AND (response_json->> '$.error' = 'phone' OR request_json->> '$.req' = '127.0')) LIMIT 1


# The results align with our expectations

   